### PR TITLE
"Login on discordlist.gg" instead of "top.gg"

### DIFF
--- a/get-started/votes-integration.md
+++ b/get-started/votes-integration.md
@@ -79,7 +79,7 @@ We apologize for the inconvenience caused.
 {% tab title="Discord List" %}
 
 
-1. Login on [top.gg](https://top.gg)
+1. Login on [discordlist.gg](https://discordlist.gg)
 2. Go to your bot's page (`https://discordlist.gg/bot/:your-bot-id`)
 3. Go to "Manage" tab
 4. Go to "Webhooks" tab


### PR DESCRIPTION
## Description
In the documentation part https://docs.discordanalytics.xyz/get-started/votes-integration#configuration, we have now (thanks) discordlist.gg, but the first link is top.gg.
![image](https://github.com/DiscordAnalytics/docs/assets/14293805/e88e8f65-3179-42e4-888f-4ceefba0cf8f)
